### PR TITLE
chore(ci): pin ruff rule set and test against Django 6.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,13 +92,22 @@ jobs:
       max-parallel: 3
       matrix:
         include:
+          # Pin the SERIES, not 6.x: "~=6.0" means >=6.0,<7.0, so the matrix silently rolls
+          # onto each new Django minor. "~=6.0.0" means >=6.0.0,<6.1.0 — new minors are a
+          # deliberate matrix addition.
           # Fast feedback with SQLite
           - python-version: "3.14"
-            django-version: "~=6.0"
+            django-version: "~=6.0.0"
             db: sqlite
           # Production configuration
           - python-version: "3.14"
-            django-version: "~=6.0"
+            django-version: "~=6.0.0"
+            db: mariadb
+          - python-version: "3.14"
+            django-version: "~=6.1.0"
+            db: sqlite
+          - python-version: "3.14"
+            django-version: "~=6.1.0"
             db: mariadb
 
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,12 @@ jobs:
           retention-days: 1
 
       - name: Django Check
-        run: python demo_app/manage.py check
+        # Use the test settings: the default settings point at MariaDB database "db",
+        # which CI never creates. This only passed before because Django <6.1 did not
+        # need a live connection to run these field checks.
+        env:
+          DB_TYPE: ${{ matrix.db }}
+        run: export PYTHONPATH=`pwd` && python demo_app/manage.py check --settings=demo_app.settings_test
 
   coverage:
     name: Coverage

--- a/README.md
+++ b/README.md
@@ -71,21 +71,20 @@ Note: If you're creating a ``DataMigration`` in
 Usage example:
 
 ```python
+p = Purchase()
 
-   p = Purchase()
+# Will automatically create state object for this purchase, in the
+# initial state.
+p.save()
+p.get_purchase_state_info().make_transition("mark_paid", request.user)  # User parameter is optional
+p.state  # Will return 'paid'
+p.get_purchase_state_info().description  # Will return 'Purchase paid'
 
-   # Will automatically create state object for this purchase, in the
-   # initial state.
-   p.save()
-   p.get_purchase_state_info().make_transition('mark_paid', request.user) # User parameter is optional
-   p.state # Will return 'paid'
-   p.get_purchase_state_info().description # Will return 'Purchase paid'
+# Returns an iterator of possible transitions for this purchase.
+p.get_purchase_state_info().possible_transitions()
 
-   # Returns an iterator of possible transitions for this purchase.
-   p.get_purchase_state_info().possible_transitions()
-
-   # Which can be used like this..
-   [x.get_name() for x in p.possible_transitions]
+# Which can be used like this..
+[x.get_name() for x in p.possible_transitions]
 ```
 
 For better transition control, override:
@@ -125,12 +124,12 @@ is. We support 2 different state groups, inclusive (only these) or
 exclusive (everything but these):
 
 ```python
+class is_paid(StateGroup):
+    states = ["paid", "shipped"]
 
-  class is_paid(StateGroup):
-      states = ['paid', 'shipped']
 
-  class is_paid(StateGroup):
-      exclude_states = ['initiated']
+class is_paid(StateGroup):
+    exclude_states = ["initiated"]
 ```
 
 ## State graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
@@ -84,6 +85,9 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
+# Pin the rule set: ruff 0.16 broadened its implicit default well beyond E/F. Opt into
+# wider rules deliberately, not via a ruff upgrade.
+select = ["E4", "E7", "E9", "F"]
 ignore = ["F401", "E402"]
 fixable = ["ALL"]
 unfixable = []


### PR DESCRIPTION
## Summary

Housekeeping only — no library behaviour changes.

**1. Pin the ruff rule set.** ruff 0.16 broadened its implicit default well beyond `E`/`F`. Since this repo doesn't pin `select`, an unpinned ruff turns the Lint job red with findings unrelated to any change here (`RUF012`, `I001`, `UP0xx`, `SIM1xx`, …). Pinning `select = ["E4","E7","E9","F"]` restores the pre-0.16 set. Adopting the wider rules should be its own deliberate PR.

This is not hypothetical: `tensor-analytics` and `tensor-registration` are already red on master from exactly this.

**2. Run ruff 0.16's formatter.** 0.16 formats python blocks inside markdown, so a few README/docs files change. No `.py` files affected.

**3. Test against Django 6.1**, and pin the existing matrix entries to the 6.0 *series*. `~=6.0` means `>=6.0,<7.0`, so the matrix had already silently rolled onto 6.1 without anyone deciding that — new minors should be a deliberate matrix change. (`simulation` already does this and carries a comment explaining why.) Classifier updated to match.

## Context

Found while bumping Axis to Django 6.1. This package's code needed **no** changes for 6.1 — its `django>=` requirement is open-ended and nothing in it touches the APIs 6.1 changed. This PR is about making CI actually prove that.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check .` clean
- [ ] CI green on both Django 6.0 and 6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)